### PR TITLE
MISPDEV-75: Fix issues with the Estonian Mobile ID implementation

### DIFF
--- a/docs/misp2_installation_manual_18.04.md
+++ b/docs/misp2_installation_manual_18.04.md
@@ -525,14 +525,17 @@ The steps for configuring HTTPS:
 #### 5.4.1 Service parameters
 
 Before moving forward with the configuration, create a `p12` trust store
-containing the correct certificate based on the documentation provided in [SK-s
-JAVA client source
-repository](https://github.com/SK-EID/mid-rest-java-client#how-to-obtain-server-certificate).
+containing the correct certificates based on the documentation provided
+in the following sections of SK-s documentation for the JAVA client:
 
-Once the trust store is created, move it to the
-`/var/lib/tomcat8/webapps/misp2/WEB-INF/classes` folder and update the file
-permissions so that it is accessible by the system user `tomcat8`. This can be
-done with the following command:
+* [How to obtain server certificate](https://github.com/SK-EID/mid-rest-java-client#how-to-obtain-server-certificate).
+* [Validate returned certificate is a trusted MID certificate](https://github.com/SK-EID/mid-rest-java-client#validate-returned-certificate-is-a-trusted-mid-certificate)
+
+Once the trust store has been created, move it to the
+`/var/lib/tomcat8/webapps/misp2/WEB-INF/classes` folder in order to use it
+from the classpath or to your preferred folder anywhere in the filesystem
+and update the file permissions so that it is accessible by the system user
+`tomcat8`. This can be done with the following command:
 
 ```bash
 # In this example, the truststore was created with the name mid_trust_store.p12
@@ -547,8 +550,15 @@ assigns the respective service name value to every institution.
 
 The parameters `mobileID.rest.trustStore.password` and
 `mobileID.rest.trustStore.path` should be updated so that the path variable
-refers to the trust store created before (e.g `/mid_trust_store.p12`) and
+refers to the trust store created before (e.g. `/mid_trust_store.p12`) and
 password contains the key needed to access it.
+
+**NB!** The `mobileID.rest.trustStore.path` searches from the following places in order:
+
+1. The classpath (e.g. if `mid_trust_store.p12` was placed inside
+   `/var/lib/tomcat8/webapps/misp2/WEB-INF/classes`, then it can be found if path has
+   been configured to `/mid_trust_store.p12`)
+2. The filesystem
 
 ### 5.5 Other settings
 

--- a/docs/misp2_installation_manual_18.04.md
+++ b/docs/misp2_installation_manual_18.04.md
@@ -542,11 +542,14 @@ and update the file permissions so that it is accessible by the system user
 sudo chown tomcat8:tomcat8 mid_trust_store.p12
 ```
 
-In the configuration file, parameters `mobileID.rest.relyingPartyUUID` and
-`mobileID.rest.relyingPartyName` must be set up with the correct value. The
+In the configuration file, parameters `mobileID.rest.relyingPartyUUID`, `mobileID.rest.hostUrl`
+and `mobileID.rest.relyingPartyName` must be set up with the correct value. The
 Certification Centre ([SK ID
 Solutions](https://www.skidsolutions.eu/en/services/mobile-id/technical-information-mid-rest-api/))
 assigns the respective service name value to every institution.
+
+In addition `auth.mobileID` must be set to `true` for the authentication
+method to be enabled.
 
 The parameters `mobileID.rest.trustStore.password` and
 `mobileID.rest.trustStore.path` should be updated so that the path variable
@@ -558,7 +561,8 @@ password contains the key needed to access it.
 1. The classpath (e.g. if `mid_trust_store.p12` was placed inside
    `/var/lib/tomcat8/webapps/misp2/WEB-INF/classes`, then it can be found if path has
    been configured to `/mid_trust_store.p12`)
-2. The filesystem
+2. The filesystem (e.g. if `mid_trust_store.p12` was placed inside `/var/foo/bar`, then it 
+   can be found if path has been configured to `/var/foo/bar/mid_trust_store.p12`)
 
 ### 5.5 Other settings
 

--- a/docs/misp2_installation_manual_18.04.md
+++ b/docs/misp2_installation_manual_18.04.md
@@ -542,9 +542,9 @@ and update the file permissions so that it is accessible by the system user
 sudo chown tomcat8:tomcat8 mid_trust_store.p12
 ```
 
-In the configuration file, parameters `mobileID.rest.relyingPartyUUID`, `mobileID.rest.hostUrl`
-and `mobileID.rest.relyingPartyName` must be set up with the correct value. The
-Certification Centre ([SK ID
+In the configuration file, parameters `mobileID.rest.relyingPartyUUID`, 
+`mobileID.rest.relyingPartyName` and `mobileID.rest.hostUrl` must be 
+set up with the correct value. The Certification Centre ([SK ID
 Solutions](https://www.skidsolutions.eu/en/services/mobile-id/technical-information-mid-rest-api/))
 assigns the respective service name value to every institution.
 

--- a/src/main/java/ee/aktors/misp2/configuration/DigiDoc4jConfiguration.java
+++ b/src/main/java/ee/aktors/misp2/configuration/DigiDoc4jConfiguration.java
@@ -54,7 +54,7 @@ public class DigiDoc4jConfiguration implements ExternallyConfigured {
     private static final String PARAM_TEST_MODE = "digidoc4j.test";
     private static final String PARAM_OCSP_SOURCE = "digidoc4j.ocsp";
     private static final String PARAM_TRUSTED_TERRITORIES = "digidoc4j.trustedTerritories";
-    private static final String PARAM_MID_ENABLED= "auth.mobileID";
+    private static final String PARAM_MID_ENABLED = "auth.mobileID";
     private static final String PARAM_MID_HOST = "mobileID.rest.hostUrl";
     private static final String PARAM_MID_PARTY_UUID = "mobileID.rest.relyingPartyUUID";
     private static final String PARAM_MID_PARTY_NAME = "mobileID.rest.relyingPartyName";

--- a/src/main/java/ee/aktors/misp2/configuration/DigiDoc4jConfiguration.java
+++ b/src/main/java/ee/aktors/misp2/configuration/DigiDoc4jConfiguration.java
@@ -25,6 +25,7 @@
 
 package ee.aktors.misp2.configuration;
 
+import ee.aktors.misp2.ExternallyConfigured;
 import ee.aktors.misp2.util.MIDTrustStoreInitialisationException;
 import ee.sk.mid.MidClient;
 import org.apache.commons.lang3.StringUtils;
@@ -33,9 +34,11 @@ import org.apache.logging.log4j.Logger;
 import org.digidoc4j.Configuration;
 import org.digidoc4j.Configuration.Mode;
 
-import ee.aktors.misp2.ExternallyConfigured;
-
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;

--- a/src/main/java/ee/aktors/misp2/configuration/DigiDoc4jConfiguration.java
+++ b/src/main/java/ee/aktors/misp2/configuration/DigiDoc4jConfiguration.java
@@ -25,6 +25,7 @@
 
 package ee.aktors.misp2.configuration;
 
+import ee.aktors.misp2.util.MIDTrustStoreInitialisationException;
 import ee.sk.mid.MidClient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -34,8 +35,7 @@ import org.digidoc4j.Configuration.Mode;
 
 import ee.aktors.misp2.ExternallyConfigured;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -54,6 +54,7 @@ public class DigiDoc4jConfiguration implements ExternallyConfigured {
     private static final String PARAM_TEST_MODE = "digidoc4j.test";
     private static final String PARAM_OCSP_SOURCE = "digidoc4j.ocsp";
     private static final String PARAM_TRUSTED_TERRITORIES = "digidoc4j.trustedTerritories";
+    private static final String PARAM_MID_ENABLED= "auth.mobileID";
     private static final String PARAM_MID_HOST = "mobileID.rest.hostUrl";
     private static final String PARAM_MID_PARTY_UUID = "mobileID.rest.relyingPartyUUID";
     private static final String PARAM_MID_PARTY_NAME = "mobileID.rest.relyingPartyName";
@@ -75,37 +76,66 @@ public class DigiDoc4jConfiguration implements ExternallyConfigured {
         digiDoc4jConfiguration = new Configuration(digiDoc4jMode);
         digiDoc4jConfiguration.setOcspSource(getOcspSource());
         digiDoc4jConfiguration.setTrustedTerritories(getTrustedTerritories());
-        LOG.debug("Launched DigiDoc4j in {} mode", digiDoc4jMode);
-        String certAliases;
+        LOG.info("Initialised DigiDoc4j in {} mode", digiDoc4jMode);
+        midClient = getMIDEnabled() ? initialiseMIDClient() : null; // Don't run MidClient initialisation if it hasn't been enabled
+    }
 
-         MidClient.MobileIdClientBuilder mobileIdClientBuilder= MidClient.newBuilder()
-            .withHostUrl(getMidHost())
-            .withRelyingPartyUUID(getMidPartyUuid())
-            .withRelyingPartyName(getMidPartyName())
-            .withLongPollingTimeoutSeconds(getMidPollingTimeoutSeconds());
-        KeyStore trustStore;
-        try (InputStream is = DigiDoc4jConfiguration.class.getResourceAsStream(getParamMidTrustStorePath())) {
-            trustStore = KeyStore.getInstance("PKCS12");
+    /**
+     * @return {@link MidClient} object based on the configuration, throws {@link MIDTrustStoreInitialisationException}
+     * if the configuration is incorrect
+     * @exception MIDTrustStoreInitialisationException thrown when configuration can not be used to create a working client
+     */
+    private MidClient initialiseMIDClient() {
+        try (InputStream is = openTrustStore()) {
+            KeyStore trustStore = KeyStore.getInstance("PKCS12");
             trustStore.load(is, getParamMidTrustStorePassword().toCharArray());
-            certAliases = Collections.list(trustStore.aliases()).stream()
-                    .reduce("cert aliases:", (list,alias) -> list.concat(", ".concat(alias)));
-        } catch (KeyStoreException | CertificateException |NoSuchAlgorithmException trustStoreException) {
-           throw new RuntimeException(
+            String certAliases = Collections.list(trustStore.aliases()).stream()
+                    .reduce("aliases:", (list,alias) -> list.concat(", ".concat(alias)));
+
+            LOG.info("Initialising MidClient with host: {}, name: {}, trustStore: {}",
+                    getMidHost(),
+                    getMidPartyName(),
+                    certAliases
+            );
+
+            MidClient.MobileIdClientBuilder mobileIdClientBuilder= MidClient.newBuilder()
+                    .withHostUrl(getMidHost())
+                    .withRelyingPartyUUID(getMidPartyUuid())
+                    .withRelyingPartyName(getMidPartyName())
+                    .withLongPollingTimeoutSeconds(getMidPollingTimeoutSeconds())
+                    .withTrustStore(trustStore);
+
+            return mobileIdClientBuilder.build();
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException trustStoreException) {
+           throw new MIDTrustStoreInitialisationException(
                    "Problem creating truststore with PKCS12 file:" + getParamMidTrustStorePath(), trustStoreException
            );
         } catch (IOException ioException) {
-            throw new RuntimeException(
-                    "Truststore reading failed from PKCS12 file:"+getParamMidTrustStorePath(), ioException
+            throw new MIDTrustStoreInitialisationException(
+                    "Truststore reading failed from PKCS12 file:" + getParamMidTrustStorePath(), ioException
             );
         }
-        mobileIdClientBuilder.withTrustStore(trustStore);
+    }
 
-        midClient =   mobileIdClientBuilder.build();
-        LOG.debug("Launched MidClient with params host:{}, name: {}, truststore: {}",
-                getMidHost(),
-                getMidPartyName(),
-                certAliases
-        );
+    /**
+     * @return {@link InputStream} for the trust store specified in the configuration.
+     * First in tries to locate the resource from the classpath, failing that, from the
+     * filesystem. If neither produces a result, a {@link FileNotFoundException} is thrown
+     * @throws FileNotFoundException trust store specified in the configuration could not be opened
+     */
+    private InputStream openTrustStore() throws FileNotFoundException {
+        String midTrustStorePath = getParamMidTrustStorePath();
+        InputStream is = DigiDoc4jConfiguration.class.getResourceAsStream(midTrustStorePath);
+
+        // We were not able to read the resource as a classpath resource,
+        // so lets try reading it from the provided path from the system
+        if (is == null) {
+            LOG.debug("Was not able to open the trust store from classpath, trying filesystem");
+            File f = new File(midTrustStorePath);
+            return new FileInputStream(f);
+        }
+
+        return is;
     }
 
     /**
@@ -122,6 +152,14 @@ public class DigiDoc4jConfiguration implements ExternallyConfigured {
      */
     private String getOcspSource() {
         return CONFIG.getString(PARAM_OCSP_SOURCE, DEFAULT_OCSP_SOURCE);
+    }
+
+    /**
+     * @return True if MID based authentication is enabled. If parameter {@value #PARAM_MID_ENABLED} is not found, then it is set to
+     *         false.
+     */
+    private boolean getMIDEnabled() {
+        return CONFIG.getBoolean(PARAM_MID_ENABLED, false);
     }
 
     /**

--- a/src/main/java/ee/aktors/misp2/service/crypto/MobileIdService.java
+++ b/src/main/java/ee/aktors/misp2/service/crypto/MobileIdService.java
@@ -113,6 +113,7 @@ public class MobileIdService {
 		if (!authenticationResult.isValid()) {
 			LOG.warn("Mobile-ID authentication was unsuccessful for phone nr: {} and ssn {}",
 					mobileIdSessionData.getPhoneNo(), mobileIdSessionData.getPersonalCode());
+			LOG.debug("Errors reported: {}", authenticationResult.getErrors());
 			throw new AuthenticationException("Mobile-ID failed to authenticate. Result is not valid.");
 		}
 

--- a/src/main/java/ee/aktors/misp2/util/MIDTrustStoreInitialisationException.java
+++ b/src/main/java/ee/aktors/misp2/util/MIDTrustStoreInitialisationException.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ * Copyright (c) 2020- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2019 Estonian Information System Authority (RIA)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package ee.aktors.misp2.util;
+
+/**
+ */
+public class MIDTrustStoreInitialisationException extends RuntimeException {
+    private static final long serialVersionUID = -3205042303590099301L;
+
+    /**
+     * @param message message to set
+     */
+    public MIDTrustStoreInitialisationException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message message to set
+     * @param cause cause to set
+     */
+    public MIDTrustStoreInitialisationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * @param cause cause to set
+     */
+    public MIDTrustStoreInitialisationException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
https://jira.niis.org/browse/MISPDEV-75

1. Refactored the code a bit to separate the MidClient initialisation from the rest of the DigiDoc4j initialisation
2. Changed generic runtime exceptions to specific ones
3. Changed the initialisation so that if `auth.mobileID` is false, the initialisation isn't even attempted
4. Changed how the trust store path is handled. Before it only searched from the classpath, now it also attempts to locate the file from the filesystem if not found in the classpath
5. If the file can not be found, an error is now logged
6. Changed some of the debug logging to info so that the initialisation steps are visible in logs even with info logging
7. Updated documentation to reflect the new behaviour and added further information about what certificates need to be included in the trust store